### PR TITLE
Fix PostgreSQL problem with given ids

### DIFF
--- a/bin/doctrine-dbal
+++ b/bin/doctrine-dbal
@@ -1,0 +1,1 @@
+../vendor/doctrine/dbal/bin/doctrine-dbal

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,0 +1,1 @@
+../vendor/phpunit/phpunit/phpunit

--- a/bin/yaml-lint
+++ b/bin/yaml-lint
@@ -1,0 +1,1 @@
+../vendor/symfony/yaml/Resources/bin/yaml-lint

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=7.1",
         "doctrine/dbal": "^2.5",
         "fzaninotto/faker": "^1.6",
-        "symfony/console": "^4.0",
-        "symfony/yaml": "^4.0"
+        "symfony/console": "^4.0 | ^5.0",
+        "symfony/yaml": "^4.0 | ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     "require": {
         "php": ">=7.1",
         "doctrine/dbal": "^2.5",
-        "fzaninotto/faker": "^1.6",
         "symfony/console": "^4.0 | ^5.0",
-        "symfony/yaml": "^4.0 | ^5.0"
+        "symfony/yaml": "^4.0 | ^5.0",
+        "fakerphp/faker": "^1.12"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "doctrine/dbal": "^2.5",
+        "doctrine/dbal": "^2.5 | ^3.3",
         "symfony/console": "^4.0 | ^5.0 | ^6.0",
         "symfony/yaml": "^4.0 | ^5.0 | ^6.0",
         "fakerphp/faker": "^1.12"

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "require": {
         "php": ">=7.1",
         "doctrine/dbal": "^2.5",
-        "symfony/console": "^4.0 | ^5.0",
-        "symfony/yaml": "^4.0 | ^5.0",
+        "symfony/console": "^4.0 | ^5.0 | ^6.0",
+        "symfony/yaml": "^4.0 | ^5.0 | ^6.0",
         "fakerphp/faker": "^1.12"
     },
     "require-dev": {

--- a/src/Database/DBALConnection.php
+++ b/src/Database/DBALConnection.php
@@ -29,7 +29,10 @@ class DBALConnection implements Connection
 
         $this->connection->executeUpdate($insert->toSQL($this->connection), $insert->parameters());
 
-        $row->assignId(@$this->connection->lastInsertId());
+        try {
+            $id = $this->connection->lastInsertId();
+            $row->assignId($id);
+        } catch (\Exception $e) {};
     }
 
     /**

--- a/src/Database/DBALConnection.php
+++ b/src/Database/DBALConnection.php
@@ -18,14 +18,18 @@ class DBALConnection implements Connection
         $this->connection = $connection;
     }
 
-    /** @throws \Doctrine\DBAL\DBALException */
+    /**
+     * @param string $table
+     * @param Row $row
+     * @throws \Doctrine\DBAL\DBALException
+     */
     public function insert(string $table, Row $row): void
     {
         $insert = Insert::into($table, $row);
 
         $this->connection->executeUpdate($insert->toSQL($this->connection), $insert->parameters());
 
-        $row->assignId($this->connection->lastInsertId());
+        $row->assignId(@$this->connection->lastInsertId());
     }
 
     /**

--- a/src/Database/Insert.php
+++ b/src/Database/Insert.php
@@ -36,7 +36,9 @@ class Insert
     {
         $parameters = [];
         foreach ($this->row->values() as $value) {
-            if (is_numeric($value) || trim($value, '`') === $value) {
+            if(is_array($value)) {
+                $parameters[] = json_encode($value);
+            } elseif (is_numeric($value) || trim($value, '`') === $value) {
                 $parameters[] = $value;
             }
         }

--- a/src/Database/Row.php
+++ b/src/Database/Row.php
@@ -76,7 +76,7 @@ class Row
     {
         $placeholders = [];
         foreach ($this->values as $column => $value) {
-            if (is_numeric($value) || trim($value, '`') === $value) {
+            if (is_array($value) || is_numeric($value) || trim($value, '`') === $value) {
                 $placeholders[$column] = '?';
             } else {
                 $placeholders[$column] = $value === null ? 'null' : trim($value, '`');

--- a/src/Processors/FakerProcessor.php
+++ b/src/Processors/FakerProcessor.php
@@ -30,7 +30,7 @@ class FakerProcessor implements PreProcessor
         }
     }
 
-    private function generateFakeDataIfNeeded(Row $row, string $column, ?string $value): void
+    private function generateFakeDataIfNeeded(Row $row, string $column, $value): void
     {
         if(!is_scalar($value)) return;
         $formatted = $value;

--- a/src/Processors/FakerProcessor.php
+++ b/src/Processors/FakerProcessor.php
@@ -32,6 +32,7 @@ class FakerProcessor implements PreProcessor
 
     private function generateFakeDataIfNeeded(Row $row, string $column, ?string $value): void
     {
+        if(!is_scalar($value)) return;
         $formatted = $value;
         while (FormatterCall::matches($formatted)) {
             $formatted = FormatterCall::from($formatted)->run($this->generator);

--- a/src/Processors/ForeignKeyProcessor.php
+++ b/src/Processors/ForeignKeyProcessor.php
@@ -59,8 +59,9 @@ class ForeignKeyProcessor implements PreProcessor, PostProcessor
     /**
      * @return mixed
      */
-    private function parseKeyIfNeeded(string $value)
+    private function parseKeyIfNeeded($value)
     {
+        if (!is_scalar($value)) return $value;
         if ($this->isAReference($value) && $this->referenceExistsFor($value)) {
             return $this->references[substr($value, 1)];
         }


### PR DESCRIPTION
Postgres Driver will throw an exception when using lastInsertId() when the insert before had a primary key field set. i modified the DBALConnect to just ignore that exception (assignId() will ignore the assign anyway when the id field is already present in $row).

Now this works for me. Hope i did not miss anything.